### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ## Getting Started
 
+[![Run on Repl.it](https://repl.it/badge/github/meedsharif/canvas-gravitational-field)](https://repl.it/github/meedsharif/canvas-gravitational-field)
+
+#or
+
 1.  Clone the repo:
 
         git clone https://github.com/meedsharif/canvas-gravitational-field.git


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).